### PR TITLE
fix(node): accident load in node environment cause undefined error

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,3 +1,4 @@
 export function getUserAgent(): string {
+  const navigator = navigator || {};
   return navigator.userAgent;
 }


### PR DESCRIPTION
This file is not correctly loaded by webpack somehow that production Node environment still try to load `navigator` and get the undefined error.
Hopefully this patch could eliminate this problem.