### PR TITLE
fix: fallback to `"<environment unknown>"` if `navigator` is undefined

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2,6 +2,6 @@ export function getUserAgent(): string {
   try {
     return navigator.userAgent;
   } catch (e) {
-    return "<navigator unknown>"
+    return "<environment unknown>"
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2,6 +2,6 @@ export function getUserAgent(): string {
   try {
     return navigator.userAgent;
   } catch (e) {
-    return 'unknown';
+    return "<navigator unknown>"
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,3 +1,7 @@
 export function getUserAgent(): string {
-  return navigator.userAgent;
+  try {
+    return navigator.userAgent;
+  } catch (e) {
+    return 'unknown';
+  }
 }


### PR DESCRIPTION
When using CloudFlare workers, the navigator is not available.

The navigator is not even set to `undefined`, so we check for the exception instead, to make sure we always handle if it fails getting the user agent.
  
  
fixes: https://github.com/octokit/graphql.js/issues/78