### PR TITLE
fix: fallback to `<environment undetectable>` in all environments

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2,6 +2,6 @@ export function getUserAgent(): string {
   try {
     return navigator.userAgent;
   } catch (e) {
-    return "<environment unknown>"
+    return "<environment undetectable>";
   }
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -10,6 +10,6 @@ export function getUserAgent(): string {
       return "Windows <version undetectable>";
     }
 
-    throw error;
+    return "<environment undetectable>";
   }
 }


### PR DESCRIPTION
### Breaking Change

- `getUserAgent()` is no longer throwing an error if it cannot determine the user agent, it falls back to `<environment undetectable>` instead