### PR TITLE
fix: handle `process.version` set to `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ export function getUserAgent() {
     return navigator.userAgent;
   }
 
-  if (typeof process === "object" && "version" in process && process.version !== undefined) {
+  if (typeof process === "object" && process.version !== undefined) {
     return `Node.js/${process.version.substr(1)} (${process.platform}; ${
       process.arch
     })`;

--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@ export function getUserAgent() {
     return navigator.userAgent;
   }
 
-  if (typeof process === "object" && "version" in process) {
+  if (typeof process === "object" && "version" in process && process.version !== undefined) {
     return `Node.js/${process.version.substr(1)} (${process.platform}; ${
       process.arch
     })`;
+  }
+
+  if (typeof EdgeRuntime === "string") {
+    return "Edge Runtime";
   }
 
   return "<environment undetectable>";

--- a/index.js
+++ b/index.js
@@ -9,9 +9,5 @@ export function getUserAgent() {
     })`;
   }
 
-  if (typeof EdgeRuntime === "string") {
-    return "Edge Runtime";
-  }
-
   return "<environment undetectable>";
 }


### PR DESCRIPTION
Resolves https://github.com/gr2m/universal-user-agent/issues/77
Related https://github.com/vercel/next.js/issues/54739

The [Edge Runtime](https://edge-runtime.vercel.app/) is not Node.js, but will have a global `process` defined. Most properties of `process` will be present but undefined, so `"version" in process` will be true. This will currently lead to a false identification as Node.js, and an error when calling `process.version.substr(1)`. This PR instead checks that `process.version !== undefined`.

It also will check if `typeof EdgeRuntime === "string"`, which is how the Edge environment is checked in Vercel, and then return user agent "Edge Runtime" (which is not standard in any way, but possibly better than nothing). When a request is actually sent from a Vercel Edge function it has the user agent "Next.js Middleware", but I don't see anyway to detect that specifically.

Let me know if you'd like me to remove this detection of the Edge Runtime and just fall back to `<environment undetectable>`.